### PR TITLE
chore: env + pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+default_language_version:
+  python: python3.7
+
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        args:
+          - --line-length=100
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: debug-statements
+      - id: requirements-txt-fixer
+      - id: check-ast # Simply check whether the files parse as valid python
+      - id: check-case-conflict # Check for files that would conflict in case-insensitive filesystems
+      - id: check-builtin-literals # Require literal syntax when initializing empty or zero Python builtin types
+      - id: check-docstring-first # Check a common error of defining a docstring after code
+      - id: check-merge-conflict # Check for files that contain merge conflict strings
+      - id: check-yaml # Check yaml files
+      - id: end-of-file-fixer # Ensure that a file is either empty, or ends with one newline
+      - id: mixed-line-ending # Replace or checks mixed line ending
+      - id: trailing-whitespace # This hook trims trailing whitespace
+
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.4.0
+    hooks:
+      - id: reorder-python-imports
+        args:
+          - --py3-plus
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+      - id: mypy
+        args:
+          - --no-strict-optional
+          - --ignore-missing-imports
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        args:
+          - --max-line-length=100
+          - --max-cognitive-complexity=15
+          - --ignore=E203,E266,E501,W503
+        additional_dependencies:
+          - pep8-naming
+          - flake8-builtins
+          - flake8-comprehensions
+          - flake8-bugbear
+          - flake8-pytest-style
+          - flake8-cognitive-complexity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Project setup
+
+- create the conda environment
+```bash
+conda env create -f environment.yaml
+```
+- install the pre-commit
+```bash
+conda activate datasets
+(datasets) pre-commit install
+```

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,7 @@
+name: datasets
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - pre-commit=2.2.0


### PR DESCRIPTION
- Conda environment with Python 3.7 + pre-commit
- pre-commit configuration with:
   - `black` as autoformatter
   - `reorder_imports` to reorder to imports automatically
   -  `mypy` to check static typing
   - `flake8` to check python conventions + common errors (e.g. mutable default argument)
   - \+ additional checks